### PR TITLE
'Network adapter' != 'Network Adapter'

### DIFF
--- a/doc/topics/cloud/map.rst
+++ b/doc/topics/cloud/map.rst
@@ -104,12 +104,12 @@ configuration:
       - db1:
           devices:
             network:
-              Network Adapter 1:
+              Network adapter 1:
                 mac: '44:44:44:44:44:41'
       - db2:
           devices:
             network:
-              Network Adapter 1:
+              Network adapter 1:
                 mac: '44:44:44:44:44:42'
 
 


### PR DESCRIPTION
The adapter name in Cloud Profile and Cloud Map should be equal, otherwise it fails to merge (in https://docs.saltstack.com/en/latest/topics/cloud/vmware.html#profiles network device name is 'Network adapter')

### What does this PR do?

Fixes documentation inconstancy 

### What issues does this PR fix or reference?

#38490

### Tests written?

No

### Commits signed with GPG?

No